### PR TITLE
Use Bioconda ChromHMM distribution

### DIFF
--- a/Envs/chromHMM.yaml
+++ b/Envs/chromHMM.yaml
@@ -1,0 +1,6 @@
+channels:
+  - bioconda
+  - conda-forge
+  - defaults
+dependencies:
+  - chromhmm=1.14-0

--- a/Rules/ChromHMM.smk
+++ b/Rules/ChromHMM.smk
@@ -213,11 +213,13 @@ rule binarize_data:
         inputs = model_inputs
     output:
         directory('ChromHMM/Binarized_Data_{tissue}_{type}')
+    conda:
+        '../Envs/chromHMM.yaml'
     params:
         peaks = lambda wildcards: '-peaks' if wildcards.type in ['PeakCalls', 'NormR'] else ''
     threads: 12
     shell:
-        'java -mx10000M -jar /home/ckern/ChromHMM/ChromHMM.jar BinarizeBed {params.peaks} {input.chroms} . {input.marks} {output}'
+        'ChromHMM.sh BinarizeBed {params.peaks} {input.chroms} . {input.marks} {output}'
 
 rule binarize_replicate:
     input:
@@ -226,9 +228,11 @@ rule binarize_replicate:
         inputs = model_replicate_inputs
     output:
         'ChromHMM/Binarized_Replicate_{tissue}_{rep}_{type}'
+    conda:
+        '../Envs/chromHMM.yaml'
     threads: 12
     shell:
-        'java -mx10000M -jar /home/ckern/ChromHMM/ChromHMM.jar BinarizeBed {input.chroms} . {input.marks} {output}'
+        'ChromHMM.sh BinarizeBed {input.chroms} . {input.marks} {output}'
         
 rule learn_model:
     input:
@@ -239,9 +243,11 @@ rule learn_model:
         emissions = 'ChromHMM/Model_{tissue}_{type}_{states}/emissions_{states}.txt'
     params:
         outdir = 'ChromHMM/Model_{tissue}_{type}_{states}'
+    conda:
+        '../Envs/chromHMM.yaml'
     threads: 12
     shell:
-        'java -mx10000M -jar /home/ckern/ChromHMM/ChromHMM.jar LearnModel -printposterior -p {threads} -l {input.chroms} {input.bindir} {params.outdir} {wildcards.states} {config[ChromHMM_genome]}'
+        'ChromHMM.sh LearnModel -printposterior -p {threads} -l {input.chroms} {input.bindir} {params.outdir} {wildcards.states} {config[ChromHMM_genome]}'
         
 rule replicate_segmentation:
     input:
@@ -252,9 +258,11 @@ rule replicate_segmentation:
         modeldir = 'ChromHMM/Model_Joint_{type}_{states}'
     output:
         'ChromHMM/Model_Joint_{type}_{states}/{tissue}_{rep}_{states}_segments.bed'
+    conda:
+        '../Envs/chromHMM.yaml'
     threads: 12
     shell:
-        'java -mx10000M -jar /home/ckern/ChromHMM/ChromHMM.jar MakeSegmentation -printposterior {input.model} {input.bindir} {input.modeldir}'
+        'ChromHMM.sh MakeSegmentation -printposterior {input.model} {input.bindir} {input.modeldir}'
         
 
 rule split_states:
@@ -327,8 +335,10 @@ rule test_num_states:
         txt = 'ChromHMM/Correlation_Tests/{type}_{states}_Comparison.txt'
     params:
         prefix = 'ChromHMM/Correlation_Tests/{type}_{states}_Comparison'
+    conda:
+        '../Envs/chromHMM.yaml'
     shell:
-        'java -mx10000M -jar /home/ckern/ChromHMM/ChromHMM.jar CompareModels {input.testmodel} {input.tissuemodels} {params.prefix}'
+        'ChromHMM.sh CompareModels {input.testmodel} {input.tissuemodels} {params.prefix}'
 
 rule pairwise_overlap:
     input:


### PR DESCRIPTION
Hello!

## Background

I was taking a look at the pipeline and saw the note about ChromHMM, `"Currently the ChromHMM portion of the pipeline does not use a conda environment"`. Since the last update, it looks like [ChromHMM has been made available through bioconda](https://anaconda.org/bioconda/chromhmm) and therefore an environment `yaml` file could be added and shell commands using `java` to call ChromHMM could be rewritten. Those are the two main parts of this pull request.

## Add chromHMM.yaml

Here I basically just copied the format of other `yaml` files for conda tools and replaced `chromhmm` as the dependency so it could be used in the snakemake rule files.

## Use conda ChromHMM in ` Rules/ChromHMM.smk `

It seems that once installed with conda ChromHMM can be called as `ChromHMM.sh`. I first tested this in just a personal conda environment on Ubuntu so I am not sure how this may differ on other operating systems. 

First, I followed the format lased in other rules and added 
```
conda:
    '../Envs/chromHMM.yaml'
```
to any rule that called ChromHMM.

Next in the shell commands, I replaced `java -mx10000M -jar /home/ckern/ChromHMM/ChromHMM.jar` where ever it occurred with `ChromHMM.sh`.

## Testing

I do not have data to fully test the pipeline with these changes but I did create a small proof of concept snakefile which is below and was named `snake-test`.

```
rule all:
    input: "results.txt"

rule test_chip:
    output:
        "results.txt"
    conda:
        "Envs/chromHMM.yaml"
    shell:'''
    ChromHMM.sh Version> {output}
    '''
```
I created a clean conda environment with the command `conda create -y --name clean -c conda-forge -c bioconda snakemake-minimal` and then executed this tiny snakefile with the command `snakemake -s snake-test -j 1 --use-conda`. This was just to test that the `chromHMM.yaml` environment file could be used successfully and that ChromHMM could be called in this way. 

The snakefile ran successfully and produced `results.txt` with the following content.
```
This is Version 1.14 of ChromHMM (c) Copyright 2008-2012 Massachusetts Institute of Technology
```
which is what I was expecting.

Based on this I believe ChromHMM calls should execute normally. However, I have not tested on Windows or Mac OS or in a full scale run.





 