### PR TITLE
Remove absolute filepaths, use conda for more dependencies

### DIFF
--- a/Envs/bdg2bw.yaml
+++ b/Envs/bdg2bw.yaml
@@ -6,3 +6,4 @@ dependencies:
   - bedtools=2.27.1
   - ucsc-bedclip
   - ucsc-bedgraphtobigwig
+  - ucsc-bedtobigbed

--- a/Envs/chromHMM.yaml
+++ b/Envs/chromHMM.yaml
@@ -1,0 +1,6 @@
+channels:
+  - bioconda
+  - conda-forge
+  - defaults
+dependencies:
+  - chromhmm=1.14-0

--- a/README.md
+++ b/README.md
@@ -39,13 +39,16 @@ The pipeline can be run with this command in your working directory:
 
 `snakemake -j 4 -s /path/to/pipeline/Snakefile --configfile config.yaml --use-conda`
 
-The -j arugment specifies how many tasks to run in parallel. The -s argument should be
+The -j argument specifies how many tasks to run in parallel. The -s argument should be
 the path to where the Snakefile file of the pipeline is on your system.
 
 If you are running the pipeline on a computing cluster, you can use the run.sh script
 included with the pipeline:
 
 `/path/to/pipeline/run.sh`
+
+Make sure to change the `--cluster-config` argument in this script
+to the path of `cluster.yaml` on your machine.
 
 This is configured for a cluster using the SLURM job scheduler. If your cluster uses
 another job scheduler you will need to modify this script. The script itself can be

--- a/Rules/Align.smk
+++ b/Rules/Align.smk
@@ -323,6 +323,9 @@ rule spp_stats:
     conda:
         '../Envs/r.yaml'
     shell: 
+        # NOTE: It looks like run_spp.R is not included in this repository
+        # I am not sure if this rule is actually used anywhere in the workflow
+        # since I have not currently run it but if it is this would break -ETH
         'Rscript /home/ckern/phantompeakqualtools/run_spp.R -c={input} -rf -out={output.stats} -p={threads} -s=0:2:400 -savp={output.figure} -tmpdir={config[tempdir]}'
 
 ############################

--- a/Rules/Align.smk
+++ b/Rules/Align.smk
@@ -322,11 +322,8 @@ rule spp_stats:
     threads: 24
     conda:
         '../Envs/r.yaml'
-    shell: 
-        # NOTE: It looks like run_spp.R is not included in this repository
-        # I am not sure if this rule is actually used anywhere in the workflow
-        # since I have not currently run it but if it is this would break -ETH
-        'Rscript /home/ckern/phantompeakqualtools/run_spp.R -c={input} -rf -out={output.stats} -p={threads} -s=0:2:400 -savp={output.figure} -tmpdir={config[tempdir]}'
+    shell:
+        'Rscript ../Scripts/run_spp.R -c={input} -rf -out={output.stats} -p={threads} -s=0:2:400 -savp={output.figure} -tmpdir={config[tempdir]}'
 
 ############################
 # Get alignment statistics #

--- a/Rules/ChromHMM.smk
+++ b/Rules/ChromHMM.smk
@@ -213,11 +213,13 @@ rule binarize_data:
         inputs = model_inputs
     output:
         directory('ChromHMM/Binarized_Data_{tissue}_{type}')
+    conda:
+        '../Envs/chromHMM.yaml'
     params:
         peaks = lambda wildcards: '-peaks' if wildcards.type in ['PeakCalls', 'NormR'] else ''
     threads: 12
     shell:
-        'java -mx10000M -jar /home/ckern/ChromHMM/ChromHMM.jar BinarizeBed {params.peaks} {input.chroms} . {input.marks} {output}'
+        'ChromHMM.sh BinarizeBed {params.peaks} {input.chroms} . {input.marks} {output}'
 
 rule binarize_replicate:
     input:
@@ -226,9 +228,11 @@ rule binarize_replicate:
         inputs = model_replicate_inputs
     output:
         'ChromHMM/Binarized_Replicate_{tissue}_{rep}_{type}'
+    conda:
+        '../Envs/chromHMM.yaml'
     threads: 12
     shell:
-        'java -mx10000M -jar /home/ckern/ChromHMM/ChromHMM.jar BinarizeBed {input.chroms} . {input.marks} {output}'
+        'ChromHMM.sh BinarizeBed {input.chroms} . {input.marks} {output}'
         
 rule learn_model:
     input:
@@ -239,9 +243,11 @@ rule learn_model:
         emissions = 'ChromHMM/Model_{tissue}_{type}_{states}/emissions_{states}.txt'
     params:
         outdir = 'ChromHMM/Model_{tissue}_{type}_{states}'
+    conda:
+        '../Envs/chromHMM.yaml'
     threads: 12
     shell:
-        'java -mx10000M -jar /home/ckern/ChromHMM/ChromHMM.jar LearnModel -printposterior -p {threads} -l {input.chroms} {input.bindir} {params.outdir} {wildcards.states} {config[ChromHMM_genome]}'
+        'ChromHMM.sh LearnModel -printposterior -p {threads} -l {input.chroms} {input.bindir} {params.outdir} {wildcards.states} {config[ChromHMM_genome]}'
         
 rule replicate_segmentation:
     input:
@@ -252,9 +258,11 @@ rule replicate_segmentation:
         modeldir = 'ChromHMM/Model_Joint_{type}_{states}'
     output:
         'ChromHMM/Model_Joint_{type}_{states}/{tissue}_{rep}_{states}_segments.bed'
+    conda:
+        '../Envs/chromHMM.yaml'
     threads: 12
     shell:
-        'java -mx10000M -jar /home/ckern/ChromHMM/ChromHMM.jar MakeSegmentation -printposterior {input.model} {input.bindir} {input.modeldir}'
+        'ChromHMM.sh MakeSegmentation -printposterior {input.model} {input.bindir} {input.modeldir}'
         
 
 rule split_states:
@@ -327,8 +335,10 @@ rule test_num_states:
         txt = 'ChromHMM/Correlation_Tests/{type}_{states}_Comparison.txt'
     params:
         prefix = 'ChromHMM/Correlation_Tests/{type}_{states}_Comparison'
+    conda:
+        '../Envs/chromHMM.yaml'
     shell:
-        'java -mx10000M -jar /home/ckern/ChromHMM/ChromHMM.jar CompareModels {input.testmodel} {input.tissuemodels} {params.prefix}'
+        'ChromHMM.sh CompareModels {input.testmodel} {input.tissuemodels} {params.prefix}'
 
 rule pairwise_overlap:
     input:

--- a/Rules/ChromHMM.smk
+++ b/Rules/ChromHMM.smk
@@ -300,6 +300,8 @@ rule tissue_specific_state_alternate:
         others = tissue_specific_inputs
     output:
         '{model}/{prefix}_Specific_{state}-{more}.bed'
+    conda:
+        '../Envs/bedtools.yaml'
     shell:
         'bedtools intersect -a {input.specific} -b {input.others} -v > {output}'
         
@@ -309,6 +311,8 @@ rule get_segment_seqs:
         genome = lambda wildcards: genomes['{}'.format(wildcards.spec)]
     output:
         '{model}/{spec}_{suffix}.fa'
+    conda:
+        '../Envs/bedtools.yaml'
     shell:
         'bedtools getfasta -fi {input.genome} -bed {input.bed} > {output}'
 
@@ -514,6 +518,8 @@ rule assign_states_to_tss:
         overlap = 'ChromHMM/Model_{scope}_{type}_{states}/{tissue}_TSS_states.txt'
     params:
         segments = lambda wildcards: 'ChromHMM/Model_{scope}_{type}_{states}/{tissue}_{states}_dense.bed'.format(type=wildcards.type, scope=wildcards.scope, states=wildcards.states, tissue=wildcards.tissue)
+    conda:
+        '../Envs/bedtools.yaml'
     shell:
         'bedtools intersect -a {input.tss} -b {params.segments} -wa -wb > {output.overlap}'
 

--- a/Rules/DeployTrackHub.smk
+++ b/Rules/DeployTrackHub.smk
@@ -76,8 +76,10 @@ rule NarrowPeak_BigBed:
         chromsizes = config['chromsizes']
     output:
         'Track_Hub/{assay}_{tissue}_Combined_Peaks.bigBed'
+    conda:
+        '../Env/bdg2bw.yaml'
     shell:
-        '/home/ckern/bin/bedToBigBed -type=bed4+1 {input} {output}'
+        'bedToBigBed -type=bed4+1 {input} {output}'
 
 rule BroadPeak_BigBed:
     input:
@@ -85,8 +87,10 @@ rule BroadPeak_BigBed:
         chromsizes = config['chromsizes']
     output:
         'Track_Hub/{assay}_{tissue}_Broad.bigBed'
+    conda:
+        '../Env/bdg2bw.yaml'
     shell:
-        '/home/ckern/bin/bedToBigBed -type=bed4+5 {input} {output}'
+        'bedToBigBed -type=bed4+5 {input} {output}'
 
 rule Temp_Peak_File:
     input:
@@ -107,8 +111,10 @@ rule RepPeak_BigBed:
         chromsizes = config['chromsizes']
     output:
         'Track_Hub/{library}_Peaks.bigBed'
+    conda:
+        '../Env/bdg2bw.yaml'
     shell:
-        '/home/ckern/bin/bedToBigBed -type=bed4 {input} {output}'
+        'bedToBigBed -type=bed4 {input} {output}'
 
 rule Segmentation_Dense_BigBed:
     input:

--- a/Rules/DeployTrackHub.smk
+++ b/Rules/DeployTrackHub.smk
@@ -7,7 +7,7 @@ rule Trim_Bedgraph:
     conda:
         '../Envs/bdg2bw.yaml'
     shell:
-        'bedtools slop -i {input.bdg} -g {input.chromsizes} -b 0 | /home/ckern/bin/bedClip stdin {input.chromsizes} {output}'
+        'bedtools slop -i {input.bdg} -g {input.chromsizes} -b 0 | bedClip stdin {input.chromsizes} {output}'
 
 rule FoldEnrichment_BigWig:
     input:
@@ -102,7 +102,7 @@ rule Temp_Peak_File:
         '../Envs/bdg2bw.yaml'
     shell:
         'grep -v chrM {input.peaks} | cut -f1,2,3,4 > {input.peaks}.temp &&'
-        'bedtools slop -i {input.peaks}.temp -g {input.chromsizes} -b 0 | /home/ckern/bin/bedClip stdin {input.chromsizes} {output} &&'
+        'bedtools slop -i {input.peaks}.temp -g {input.chromsizes} -b 0 | bedClip stdin {input.chromsizes} {output} &&'
         'rm {input.peaks}.temp'
 
 rule RepPeak_BigBed:

--- a/Scripts/run_spp.R
+++ b/Scripts/run_spp.R
@@ -1,0 +1,887 @@
+#!/usr/bin/env Rscript
+# run_spp.R
+# =============
+# Author: Anshul Kundaje, Computer Science Dept., MIT
+# Email: anshul@kundaje.net
+# Last updated: Aug 29, 2016
+# =============
+# MANDATORY ARGUMENTS
+# -c=<ChIP_tagAlign/BAMFile>, full path and name of tagAlign/BAM file (can be gzipped) (FILE EXTENSION MUST BE tagAlign.gz, tagAlign, bam or bam.gz)
+# MANDATORY ARGUMENT FOR PEAK CALLING
+# -i=<Input_tagAlign/BAMFile>, full path and name of tagAlign/BAM file (can be gzipped) (FILE EXTENSION MUST BE tagAlign.gz, tagAlign, bam or bam.gz)
+# OPTIONAL ARGUMENTS
+# -s=<min>:<step>:<max> , strand shifts at which cross-correlation is evaluated, default=-500:5:1500
+# -speak=<strPeak>, user-defined cross-correlation peak strandshift
+# -x=<min>:<max>, strand shifts to exclude (This is mainly to avoid phantom peaks) default=10:(readlen+10)
+# -p=<nodes> , number of parallel processing nodes, default=NULL
+# -fdr=<falseDisoveryRate> , false discovery rate threshold for peak calling
+# -npeak=<numPeaks>, threshold on number of peaks to call
+# -tmpdir=<tempdir> , Temporary directory (if not specified R function tempdir() is used)
+# -filtchr=<chrnamePattern> , Pattern to use to remove tags that map to specific chromosomes e.g. _ will remove all tags that map to chromosomes with _ in their name
+# OUTPUT PARAMETERS
+# -odir=<outputDirectory> name of output directory (If not set same as ChIP file directory is used)
+# -savn=<narrowpeakfilename> OR -savn NarrowPeak file name
+# -savr=<regionpeakfilename> OR -savr RegionPeak file name
+# -savd=<rdatafile> OR -savd , save Rdata file
+# -savp=<plotdatafile> OR -savp , save cross-correlation plot
+# -out=<resultfile>, append peakshift result to a file 
+#      format:Filename<tab>numReads<tab>estFragLen<tab>corr_estFragLen<tab>PhantomPeak<tab>corr_phantomPeak<tab>argmin_corr<tab>min_corr<tab>Normalized SCC (NSC)<tab>Relative SCC (RSC)<tab>QualityTag
+# -rf , if plot or rdata or narrowPeak file exists replace it. If not used then the run is aborted if the plot or Rdata or narrowPeak file exists
+# -clean, if present will remove the original chip and control files after reading them in. CAUTION: Use only if the script calling run_spp.R is creating temporary files
+library(caTools)
+args <- commandArgs(trailingOnly=TRUE); # Read Arguments from command line
+nargs = length(args); # number of arguments
+
+# ###########################################################################
+# AUXILIARY FUNCTIONS
+# ###########################################################################
+
+print.usage <- function() {
+# ===================================
+# Function will print function usage
+# ===================================	
+	cat('Usage: Rscript run_spp.R <options>\n',file=stderr())
+	cat('MANDATORY ARGUMENTS\n',file=stderr())
+	cat('-c=<ChIP_alignFile>, full path and name (or URL) of tagAlign/BAM file (can be gzipped) (FILE EXTENSION MUST BE tagAlign.gz, tagAlign, bam or bam.gz) \n',file=stderr())
+	cat('MANDATORY ARGUMENTS FOR PEAK CALLING\n',file=stderr())
+	cat('-i=<Input_alignFile>, full path and name (or URL) of tagAlign/BAM file (can be gzipped) (FILE EXTENSION MUST BE tagAlign.gz, tagAlign, bam or bam.gz) \n',file=stderr())
+	cat('OPTIONAL ARGUMENTS\n',file=stderr())
+	cat('-s=<min>:<step>:<max> , strand shifts at which cross-correlation is evaluated, default=-500:5:1500\n',file=stderr())
+	cat('-speak=<strPeak>, user-defined cross-correlation peak strandshift\n',file=stderr())
+	cat('-x=<min>:<max>, strand shifts to exclude (This is mainly to avoid region around phantom peak) default=10:(readlen+10)\n',file=stderr())
+	cat('-p=<nodes> , number of parallel processing nodes, default=0\n',file=stderr())
+	cat('-fdr=<falseDisoveryRate> , false discovery rate threshold for peak calling\n',file=stderr())
+	cat('-npeak=<numPeaks>, threshold on number of peaks to call\n',file=stderr())    
+	cat('-tmpdir=<tempdir> , Temporary directory (if not specified R function tempdir() is used)\n',file=stderr())
+	cat('-filtchr=<chrnamePattern> , Pattern to use to remove tags that map to specific chromosomes e.g. _ will remove all tags that map to chromosomes with _ in their name\n',file=stderr())
+	cat('OUTPUT ARGUMENTS\n',file=stderr())
+	cat('-odir=<outputDirectory> name of output directory (If not set same as ChIP file directory is used)\n',file=stderr())
+	cat('-savn=<narrowpeakfilename> OR -savn NarrowPeak file name (fixed width peaks)\n',file=stderr())
+	cat('-savr=<regionpeakfilename> OR -savr RegionPeak file name (variable width peaks with regions of enrichment)\n',file=stderr())
+	cat('-savd=<rdatafile> OR -savd, save Rdata file\n',file=stderr())
+	cat('-savp=<plotdatafile> OR -savp, save cross-correlation plot\n',file=stderr())
+	cat('-out=<resultfile>, append peakshift/phantomPeak results to a file\n',file=stderr())
+	cat('     format:Filename<tab>numReads<tab>estFragLen<tab>corr_estFragLen<tab>PhantomPeak<tab>corr_phantomPeak<tab>argmin_corr<tab>min_corr<tab>Normalized SCC (NSC)<tab>Relative SCC (RSC)<tab>QualityTag)\n',file=stderr())
+	cat('-rf, if plot or rdata or narrowPeak file exists replace it. If not used then the run is aborted if the plot or Rdata or narrowPeak file exists\n',file=stderr())
+	cat('-clean, if present will remove the original chip and control files after reading them in. CAUTION: Use only if the script calling run_spp.R is creating temporary files\n',file=stderr())
+} # end: print.usage()
+
+get.file.parts <- function(file.fullpath) {
+# ===================================
+# Function will take a file name with path and split the file name into 
+# path, fullname, name and ext
+# ===================================	
+	if (! is.character(file.fullpath)) {
+		stop('File name must be a string')
+	}
+	
+	file.parts <- strsplit(as.character(file.fullpath), .Platform$file.sep, fixed=TRUE)[[1]] # split on file separator
+	
+	if (length(file.parts) == 0) { # if empty file name
+		return(list(path='',
+						fullname='',
+						name='',
+						ext='')
+		)
+	} else {
+		if (length(file.parts) == 1) { # if no path then just the file name itself
+			file.path <- '.'
+			file.fullname <- file.parts
+		} else {
+			file.path <- paste(file.parts[1:(length(file.parts)-1)], collapse=.Platform$file.sep) # 1:last-1 token is path
+			file.fullname <- file.parts[length(file.parts)] # last token is filename
+		}        
+		file.fullname.parts <- strsplit(file.fullname,'.',fixed=TRUE)[[1]] # split on .
+		if (length(file.fullname.parts) == 1) { # if no extension
+			file.ext <- ''
+			file.name <- file.fullname.parts
+		} else {
+			file.ext <- paste('.', file.fullname.parts[length(file.fullname.parts)], sep="") # add the . to the last token
+			file.name <- paste(file.fullname.parts[1:(length(file.fullname.parts)-1)], collapse=".")
+		}
+		return(list(path=file.path,
+						fullname=file.fullname,
+						name=file.name,
+						ext=file.ext))
+	}         	
+} # end: get.file.parts()
+
+parse.arguments <- function(args) {
+# ===================================
+# Function will parse arguments
+# ===================================	
+	# Set arguments to default values
+	chip.file <- NA  # main ChIP tagAlign/BAM file name
+	isurl.chip.file <- FALSE # flag indicating whether ChIP file is a URL
+	control.file <- NA # control tagAlign/BAM file name
+	isurl.control.file <- FALSE # flag indicating whether control file is a URL   
+	sep.min <- -500  # min strand shift
+	sep.max <- 1500  # max strand shift
+	sep.bin <- 5    # increment for strand shift
+	sep.peak <- NA # user-defined peak shift
+	exclude.min <- 10 # lowerbound of strand shift exclusion region
+	exclude.max <- NaN # upperbound of strand shift exclusion region
+	n.nodes <- NA # number of parallel processing nodes
+	fdr <- 0.01 # false discovery rate threshold for peak calling
+	npeak <- NA # threshold on number of peaks to call
+	temp.dir <- tempdir() # temporary directory
+	chrname.rm.pattern <- NA # chromosome name pattern used to remove tags
+	output.odir <- NA # Output directory name
+	output.npeak.file <- NA # Output narrowPeak file name
+	output.rpeak.file <- NA # Output regionPeak file name
+	output.rdata.file <- NA # Rdata file
+	output.plot.file <- NA  # cross correlation plot file
+	output.result.file <- NA # result file
+	replace.flag <- FALSE # replace file flag
+	clean.files.flag <- FALSE # file deletion flag
+	
+	# Parse arguments   
+	for (each.arg in args) {
+		
+		if (grepl('^-c=',each.arg)) { #-c=<chip.file>
+			
+			arg.split <- strsplit(each.arg,'=',fixed=TRUE)[[1]] # split on =
+			if (! is.na(arg.split[2]) ) {
+				chip.file <- arg.split[2] # second part is chip.file
+			} else {
+				stop('No tagAlign/BAM file name provided for parameter -c=')
+			}
+			
+		} else if (grepl('^-i=',each.arg)) { #-i=<control.file>
+			
+			arg.split <- strsplit(each.arg,'=',fixed=TRUE)[[1]] # split on =
+			if (! is.na(arg.split[2]) ) {
+				control.file <- arg.split[2] # second part is control.file
+			} else {
+				stop('No tagAlign/BAM file name provided for parameter -i=')
+			}
+			
+		} else if (grepl('^-s=',each.arg)) { #-s=<sep.min>:<sep.bin>:<sep.max>
+			
+			arg.split <- strsplit(each.arg,'=',fixed=TRUE)[[1]] # split on =
+			if (! is.na(arg.split[2]) ) {
+				sep.vals <- arg.split[2] # second part is sepmin:sepbin:sepmax
+				sep.vals.split <- strsplit(sep.vals,':',fixed=TRUE)[[1]] # split on :                
+				if (length(sep.vals.split) != 3) { # must have 3 parts
+					stop('Strand shift limits must be specified as -s=sepmin:sepbin:sepmax')                    
+				} else {
+					if (any(is.na(as.numeric(sep.vals.split)))) { # check that sep vals are numeric
+						stop('Strand shift limits must be numeric values')
+					}
+					sep.min <- round(as.numeric(sep.vals.split[1]))
+					sep.bin <- round(as.numeric(sep.vals.split[2]))
+					sep.max <- round(as.numeric(sep.vals.split[3]))
+					if ((sep.min > sep.max) || (sep.bin > (sep.max - sep.min)) || (sep.bin < 0)) {
+						stop('Illegal separation values -s=sepmin:sepbin:sepmax')
+					}
+				}                                    
+			} else {
+				stop('Strand shift limits must be specified as -s=sepmin:sepbin:sepmax')
+			}
+			
+		} else if (grepl('^-speak=',each.arg)) { #-speak=<sep.peak> , user-defined cross-correlation peak strandshift
+			
+			arg.split <- strsplit(each.arg,'=',fixed=TRUE)[[1]] # split on =
+			if (! is.na(arg.split[2]) ) {
+				sep.peak <- arg.split[2] # second part is <sep.peak>
+				if (is.na(as.numeric(sep.peak))) { # check that sep.peak is numeric
+					stop('-speak=<sep.peak>: User defined peak shift must be numeric')
+				}
+				sep.peak <- as.numeric(sep.peak)
+			} else {
+				stop('User defined peak shift must be provided as -speak=<sep.peak>')
+			}
+			
+		} else if (grepl('^-x=',each.arg)) { #-x=<exclude.min>:<exclude.max>
+			
+			arg.split <- strsplit(each.arg,'=',fixed=TRUE)[[1]] # split on =
+			if (! is.na(arg.split[2]) ) {
+				exclude.vals <- arg.split[2] # second part is excludemin:excludemax
+				exclude.vals.split <- strsplit(exclude.vals,':',fixed=TRUE)[[1]] # split on :                
+				if (length(exclude.vals.split) != 2) { # must have 2 parts
+					stop('Exclusion limits must be specified as -x=excludemin:excludemax')
+				} else {
+					if (any(is.na(as.numeric(exclude.vals.split)))) { # check that exclude vals are numeric
+						stop('Exclusion limits must be numeric values')
+					}
+					exclude.min <- round(as.numeric(exclude.vals.split[1]))                    
+					exclude.max <- round(as.numeric(exclude.vals.split[2]))
+					if (exclude.min > exclude.max) {
+						stop('Illegal exclusion limits -x=excludemin:excludemax')
+					}                    
+				}                                    
+			} else {
+				stop('Exclusion limits must be specified as -x=excludemin:excludemax')
+			}
+			
+		} else if (grepl('^-p=',each.arg)) { #-p=<n.nodes> , number of parallel processing nodes, default=NULL            
+			
+			arg.split <- strsplit(each.arg,'=',fixed=TRUE)[[1]] # split on =
+			if (! is.na(arg.split[2]) ) {
+				n.nodes <- arg.split[2] # second part is numnodes
+				if (is.na(as.numeric(n.nodes))) { # check that n.nodes is numeric
+					stop('-p=<numnodes>: numnodes must be numeric')
+				}
+				n.nodes <- round(as.numeric(n.nodes))
+			} else {
+				stop('Number of parallel nodes must be provided as -p=<numnodes>')
+			}
+			
+		} else if (grepl('^-fdr=',each.arg)) { #-fdr=<fdr> , false discovery rate, default=0.01            
+			
+			arg.split <- strsplit(each.arg,'=',fixed=TRUE)[[1]] # split on =
+			if (! is.na(arg.split[2]) ) {
+				fdr <- arg.split[2] # second part is fdr
+				if (is.na(as.numeric(fdr))) { # check that fdr is numeric
+					stop('-fdr=<falseDiscoveryRate>: false discovery rate must be numeric')
+				}
+				fdr <- as.numeric(fdr)
+			} else {
+				stop('False discovery rate must be provided as -fdr=<fdr>')
+			}
+			
+		} else if (grepl('^-npeak=',each.arg)) { #-npeak=<numPeaks> , number of peaks threshold, default=NA            
+			
+			arg.split <- strsplit(each.arg,'=',fixed=TRUE)[[1]] # split on =
+			if (! is.na(arg.split[2]) ) {
+				npeak <- arg.split[2] # second part is npeak
+				if (is.na(as.numeric(npeak))) { # check that npeak is numeric
+					stop('-npeak=<numPeaks>: threshold on number of peaks must be numeric')
+				}
+				npeak <- round(as.numeric(npeak))
+			} else {
+				stop('Threshold on number of peaks must be provided as -npeak=<numPeaks>')
+			}
+			
+		} else if (grepl('^-tmpdir=',each.arg)) { #-tmpdir=<temp.dir>
+			
+			arg.split <- strsplit(each.arg,'=',fixed=TRUE)[[1]] # split on =
+			if (! is.na(arg.split[2]) ) {
+				temp.dir <- arg.split[2] # second part is temp.dir
+			} else {
+				stop('No temporary directory provided for parameter -tmpdir=')
+			}
+
+		} else if (grepl('^-filtchr=',each.arg)) { #-filtchr=<chrname.rm.pattern>
+			
+			arg.split <- strsplit(each.arg,'=',fixed=TRUE)[[1]] # split on =
+			if (! is.na(arg.split[2]) ) {
+				chrname.rm.pattern <- arg.split[2] # second part is chrname.rm.pattern
+			} else {
+				stop('No pattern provided for parameter -filtchr=')
+			}
+			
+		} else if (grepl('^-odir=',each.arg)) { #-odir=<output.odir>
+			
+			arg.split <- strsplit(each.arg,'=',fixed=TRUE)[[1]] # split on =
+			if (! is.na(arg.split[2]) ) {
+				output.odir <- arg.split[2] # second part is output.odir
+			} else {
+				stop('No output directory provided for parameter -odir=')
+			}
+			
+		} else if (grepl('^-savn',each.arg)) { # -savn=<output.npeak.file> OR -savn , save narrowpeak
+			
+			arg.split <- strsplit(each.arg,'=',fixed=TRUE)[[1]] # split on =
+			if (! is.na(arg.split[2])) {                
+				output.npeak.file <- arg.split[2] #-savn=
+			} else if (each.arg=='-savn') {
+				output.npeak.file <- NULL # NULL indicates get the name from the main file name
+			} else {
+				stop('Argument for saving narrowPeak file must be -savn or -savn=<filename>')
+			}
+			
+		} else if (grepl('^-savr',each.arg)) { # -savr=<output.rpeak.file> OR -savr , save regionpeak
+			
+			arg.split <- strsplit(each.arg,'=',fixed=TRUE)[[1]] # split on =
+			if (! is.na(arg.split[2])) {                
+				output.rpeak.file <- arg.split[2] #-savr=
+			} else if (each.arg=='-savr') {
+				output.rpeak.file <- NULL # NULL indicates get the name from the main file name
+			} else {
+				stop('Argument for saving regionPeak file must be -savr or -savr=<filename>')
+			}
+			
+		} else if (grepl('^-savd',each.arg)) { # -savd=<output.rdata.file> OR -savd , save Rdata file
+			
+			arg.split <- strsplit(each.arg,'=',fixed=TRUE)[[1]] # split on =
+			if (! is.na(arg.split[2])) {                
+				output.rdata.file <- arg.split[2] #-savd=
+			} else if (each.arg=='-savd') {
+				output.rdata.file <- NULL # NULL indicates get the name from the main file name
+			} else {
+				stop('Argument for saving Rdata file must be -savd or -savd=<filename>')
+			}
+			
+		} else if (grepl('^-savp',each.arg)) { # -savp=<output.plot.file> OR -savp , save cross-correlation plot                       
+			
+			arg.split <- strsplit(each.arg,'=',fixed=TRUE)[[1]] # split on =
+			if (! is.na(arg.split[2])) {                
+				output.plot.file <- arg.split[2] #-savp=
+			} else if (each.arg=='-savp') {
+				output.plot.file <- NULL # NULL indicates get the name from the main file name
+			} else {
+				stop('Argument for saving Rdata file must be -savp or -savp=<filename>')
+			}
+			
+		} else if (grepl('^-out=',each.arg)) { #-out=<output.result.file>
+			
+			arg.split <- strsplit(each.arg,'=',fixed=TRUE)[[1]] # split on =
+			if (! is.na(arg.split[2]) ) {
+				output.result.file <- arg.split[2] # second part is output.result.file
+			} else {
+				stop('No result file provided for parameter -out=')
+			}
+		
+		} else if (each.arg == '-rf') {
+			
+			replace.flag <- TRUE
+		
+		} else if (each.arg == '-clean') {
+			
+			clean.files.flag <- TRUE
+			
+		} else {
+			
+			stop('Illegal argument ',each.arg)
+		}        
+	}
+	# End: for loop
+	
+	# Check mandatory arguments
+	if (is.na(chip.file)) {
+		stop('-c=<tagAlign/BAMFileName> is a mandatory argument')
+	}
+	
+	if (is.na(control.file) && ! is.na(output.npeak.file)) {
+		stop('-i=<tagAlign/BAMFileName> is required for peak calling')
+	}
+	
+	# Check if ChIP and control files are URLs
+	if (grepl('^http://',chip.file)) {
+		isurl.chip.file <- TRUE
+	}
+	if (grepl('^http://',control.file)) {
+		isurl.control.file <- TRUE
+	}
+	
+	# If ChIP file is a URL output.odir MUST be specified
+	if (isurl.chip.file && is.na(output.odir)) {
+		stop('If ChIP file is a URL, then output directory MUST be specified')
+	}
+	
+	# Check that ChIP and control files exist
+	if (isurl.chip.file) {
+		if (system(paste('wget -q --spider',chip.file)) != 0) {
+			stop('ChIP file URL not valid: ',chip.file)
+		}
+	} else if (!file.exists(chip.file)) {
+		stop('ChIP File:',chip.file,' does not exist')
+	}
+	
+	if (!is.na(control.file)) {
+		if (isurl.control.file) {
+			if (system(paste('wget -q --spider',control.file)) != 0) {
+				stop('Control file URL not valid: ',control.file)
+			}
+		} else if (!file.exists(control.file)) {
+			stop('Control File:',control.file,' does not exist')
+		}   
+	}
+	
+	# Correct other arguments
+	if (is.na(output.odir)) { # Reconstruct output.odir if not provided
+		output.odir <- get.file.parts(chip.file)$path
+	}
+	
+	if (is.null(output.npeak.file)) { # Reconstruct output.npeak.file if NULL
+		output.npeak.file <- file.path(output.odir, paste(get.file.parts(chip.file)$name, '_VS_', get.file.parts(control.file)$name,'.narrowPeak', sep=""))
+	}
+	
+	if (is.null(output.rpeak.file)) { # Reconstruct output.rpeak.file if NULL
+		output.rpeak.file <- file.path(output.odir, paste(get.file.parts(chip.file)$name, '_VS_', get.file.parts(control.file)$name,'.regionPeak', sep=""))
+	}
+	
+	if (is.null(output.rdata.file)) { # Reconstruct output.rdata.file if NULL
+		output.rdata.file <- file.path(output.odir, paste(get.file.parts(chip.file)$name, '.Rdata', sep=""))
+	}
+	
+	if (is.null(output.plot.file)) { # Reconstruct output.plot.file if NULL
+		output.plot.file <- file.path(output.odir, paste(get.file.parts(chip.file)$name, '.pdf', sep=""))
+	}
+	
+	return(list(chip.file=chip.file,
+					isurl.chip.file=isurl.chip.file,
+					control.file=control.file,
+					isurl.control.file=isurl.control.file,
+					sep.range=c(sep.min,sep.bin,sep.max),
+					sep.peak=sep.peak,
+					ex.range=c(exclude.min,exclude.max),
+					n.nodes=n.nodes,
+					fdr=fdr,
+					npeak=npeak,
+					temp.dir=temp.dir,
+					chrname.rm.pattern=chrname.rm.pattern,
+					output.odir=output.odir,
+					output.npeak.file=output.npeak.file,
+					output.rpeak.file=output.rpeak.file,
+					output.rdata.file=output.rdata.file,
+					output.plot.file=output.plot.file,
+					output.result.file=output.result.file,
+					replace.flag=replace.flag,
+					clean.files.flag=clean.files.flag))          
+} # end: parse.arguments()
+
+read.align <- function(align.filename) {
+# ===================================
+# Function will read a tagAlign or BAM file
+# ===================================	
+	if (grepl('(\\.bam)?.*(\\.tagAlign)',align.filename)) { # if tagalign file
+		chip.data <- read.tagalign.tags(align.filename)
+		# get readlength info
+		tmpDataRows <- read.table(align.filename,nrows=500)
+		chip.data$read.length <- round(median(tmpDataRows$V3 - tmpDataRows$V2))
+	} else if (grepl('(\\.tagAlign)?.*(\\.bam)',align.filename)) { # if bam file
+		# create BAM file name
+		bam2align.filename <- sub('\\.bam','.tagAlign',align.filename)
+		# generate command to convert bam to tagalign
+		command <- vector(length=2)
+		command[1] <- sprintf("samtools view -F 0x0204 -o - %s",align.filename)
+		command[2] <- paste("awk 'BEGIN{FS=" , '"\t"' , ";OFS=", '"\t"} {if (and($2,16) > 0) {print $3,($4-1),($4-1+length($10)),"N","1000","-"} else {print $3,($4-1),($4-1+length($10)),"N","1000","+"}}', "' 1> ", bam2align.filename, sep="")
+		# command[2] <- paste("awk 'BEGIN{OFS=", '"\t"} {if (and($2,16) > 0) {print $3,($4-1),($4-1+length($10)),"N","1000","-"} else {print $3,($4-1),($4-1+length($10)),"N","1000","+"}}', "' 1> ", bam2align.filename, sep="")	
+		command <- paste(command,collapse=" | ")
+		# Run command
+		status <- system(command,intern=FALSE,ignore.stderr=FALSE)
+		if ((status != 0) || !file.exists(bam2align.filename)) {
+			cat(sprintf("Error converting BAM to tagalign file: %s\n",align.filename),file=stderr())
+			q(save="no",status=1)
+		}
+		# read converted BAM file
+		chip.data <- read.tagalign.tags(bam2align.filename)
+		# get readlength info
+		tmpDataRows <- read.table(bam2align.filename,nrows=500)
+		chip.data$read.length <- round(median(tmpDataRows$V3 - tmpDataRows$V2))
+		# delete temporary tagalign file
+		file.remove(bam2align.filename)	
+	} else {
+		cat(sprintf("Error:Unknown file format for file:%s\n",align.fname),file=stderr())
+		q(save="no",status=1)	
+	}
+	return(chip.data)
+} # end: read.align()
+
+print.run.params <- function(params){
+# ===================================
+# Output run parameters
+# ===================================		
+	cat('################\n',file=stdout())
+	cat(iparams$chip.file,
+			iparams$control.file,
+			iparams$sep.range,
+			iparams$sep.peak,
+			iparams$ex.range,
+			iparams$n.nodes,
+			iparams$fdr,
+			iparams$npeak,
+			iparams$output.odir,
+			iparams$output.npeak.file,
+			iparams$output.rpeak.file,
+			iparams$output.rdata.file,
+			iparams$output.plot.file,
+			iparams$output.result.file,
+			iparams$replace.flag,  
+			labels=c('ChIP data:','Control data:', 'strandshift(min):','strandshift(step):','strandshift(max)','user-defined peak shift',
+					'exclusion(min):','exclusion(max):','num parallel nodes:','FDR threshold:','NumPeaks Threshold:','Output Directory:',
+					'narrowPeak output file name:', 'regionPeak output file name:', 'Rdata filename:', 
+					'plot pdf filename:','result filename:','Overwrite files?:'),
+			fill=18,
+			file=stdout())	
+	cat('\n',file=stdout())	
+} # end: print.run.parameters()
+
+check.replace.flag <- function(params){
+# ===================================
+# Check if files exist
+# ===================================
+# If replace.flag is NOT set, check if output files exist and abort if necessary
+	if (! iparams$replace.flag) {
+		if (! is.na(iparams$output.npeak.file)) {
+			if (file.exists(iparams$output.npeak.file)) {
+				cat('narrowPeak file already exists. Aborting Run. Use -rf if you want to overwrite\n',file=stderr())
+				q(save="no",status=1)
+			}
+		}
+		if (! is.na(iparams$output.rpeak.file)) {
+			if (file.exists(iparams$output.rpeak.file)) {
+				cat('regionPeak file already exists. Aborting Run. Use -rf if you want to overwrite\n',file=stderr())
+				q(save="no",status=1)
+			}
+		}    
+		if (! is.na(iparams$output.plot.file)) {
+			if (file.exists(iparams$output.plot.file)) {
+				cat('Plot file already exists. Aborting Run. Use -rf if you want to overwrite\n',file=stderr())
+				q(save="no",status=1)
+			}
+		}
+		if (! is.na(iparams$output.rdata.file)) {
+			if (file.exists(iparams$output.rdata.file)) {
+				cat('Rdata file already exists. Aborting Run. Use -rf if you want to overwrite\n',file=stderr())
+				q(save="no",status=1)
+			}
+		}
+	}	
+}
+
+# #############################################################################
+# MAIN FUNCTION
+# #############################################################################
+
+# Load SPP library
+library(spp)
+library(caTools)
+
+# Check number of arguments
+minargs = 1;
+maxargs = 17;
+if (nargs < minargs | nargs > maxargs) {
+	print.usage()
+	q(save="no",status=1)
+}
+
+# Parse arguments
+# iparams$chip.file
+# iparams$isurl.chip.file
+# iparams$control.file
+# iparams$isurl.control.file
+# iparams$sep.range
+# iparams$sep.peak
+# iparams$ex.range
+# iparams$n.nodes
+# iparams$fdr
+# iparams$npeak
+# iparams$temp.dir
+# iparams$output.odir
+# iparams$output.npeak.file
+# iparams$output.rpeak.file
+# iparams$output.rdata.file
+# iparams$output.plot.file
+# iparams$output.result.file
+# iparams$replace.flag
+# iparams$clean.files.flag
+iparams <- parse.arguments(args)
+
+# Print run parameters
+print.run.params(iparams)
+
+# Check if output files exist 
+check.replace.flag(iparams)
+
+# curr.chip.file and curr.control.file always point to the original ChIP and control files on disk
+# ta.chip.filename & ta.control.filename always point to the final but temporary versions of the ChIP and control files that will be passed to read.align
+
+# Download ChIP and control files if necessary to temp.dir
+if (iparams$isurl.chip.file) {
+	curr.chip.file <- file.path(iparams$temp.dir, get.file.parts(iparams$chip.file)$fullname) # file is downloaded to temp.dir. Has same name as URL suffix
+	cat('Downloading ChIP file:',iparams$chip.file,"\n",file=stdout())
+	if (system(paste('wget -N -q -P',iparams$temp.dir,iparams$chip.file)) != 0) {
+		stop('Error downloading ChIP file:',iparams$chip.file)
+	}
+} else {
+	curr.chip.file <- iparams$chip.file # file is in original directory
+}
+
+if (iparams$isurl.control.file) {
+	curr.control.file <- file.path(iparams$temp.dir, get.file.parts(iparams$control.file)$fullname) # file is downloaded to temp.dir. Has same name as URL suffix
+	cat('Downloading control file:',iparams$control.file,"\n",file=stdout())
+	if (system(paste('wget -N -q -P',iparams$temp.dir,iparams$control.file)) != 0) {
+		stop('Error downloading Control file:',iparams$control.file)
+	}
+} else {
+	curr.control.file <- iparams$control.file # file is in original directory
+}
+
+# unzip ChIP and input files if required AND copy to temp directory
+if (get.file.parts(curr.chip.file)$ext == '.gz') {
+	ta.chip.filename <- tempfile(get.file.parts(curr.chip.file)$name, tmpdir=iparams$temp.dir) # unzip file to temp.dir/[filename with .gz removed][randsuffix]
+	cat('Decompressing ChIP file\n',file=stdout())
+	if (system(paste("gunzip -c",curr.chip.file,">",ta.chip.filename)) != 0) {
+		stop('Unable to decompress file:', iparams$chip.file)
+	}
+	if (iparams$clean.files.flag) { # Remove original file if clean.files.flag is set
+		file.remove(curr.chip.file)
+	}
+} else {
+	ta.chip.filename <- tempfile(get.file.parts(curr.chip.file)$fullname, tmpdir=iparams$temp.dir)
+	if (iparams$clean.files.flag) {
+		file.rename(curr.chip.file,ta.chip.filename) # move file to temp.dir/[filename][randsuffix]
+	} else {
+		file.copy(curr.chip.file,ta.chip.filename) # copy file to temp.dir/[filename][randsuffix]		
+	}	
+}
+
+if (! is.na(iparams$control.file)) {
+	if (get.file.parts(curr.control.file)$ext == '.gz') {
+		ta.control.filename <- tempfile(get.file.parts(curr.control.file)$name, tmpdir=iparams$temp.dir) # unzip file to temp.dir/[filename with .gz removed][randsuffix]
+		cat('Decompressing control file\n',file=stdout())        
+		if (system(paste("gunzip -c",curr.control.file,">",ta.control.filename)) != 0) {
+			stop('Unable to decompress file:', iparams$control.file)
+		}
+		if (iparams$clean.files.flag) { # Remove original file if clean.files.flag is set
+			file.remove(curr.control.file)
+		}				
+	} else {
+		ta.control.filename <- tempfile(get.file.parts(curr.control.file)$fullname, tmpdir=iparams$temp.dir) # copy file to temp.dir/[filename][randsuffix]
+		
+		if (iparams$clean.files.flag) {
+			file.rename(curr.control.file,ta.control.filename) # move file to temp.dir/[filename][randsuffix]
+		} else {
+			file.copy(curr.control.file,ta.control.filename) # copy file to temp.dir/[filename][randsuffix]		
+		}			
+	}
+}
+
+# Remove downloaded files
+if (iparams$isurl.chip.file & file.exists(curr.chip.file))  {
+	file.remove(curr.chip.file)
+}
+
+if (! is.na(iparams$control.file)) {
+	if (iparams$isurl.control.file & file.exists(curr.control.file)) {
+		file.remove(curr.control.file)
+	}
+}
+
+# Read ChIP tagAlign/BAM files
+cat("Reading ChIP tagAlign/BAM file",iparams$chip.file,"\n",file=stdout())
+chip.data <- read.align(ta.chip.filename)
+cat("ChIP data read length",chip.data$read.length,"\n",file=stdout())
+file.remove(ta.chip.filename) # Delete temporary file
+if (length(chip.data$tags)==0) {
+	stop('Error in ChIP file format:', iparams$chip.file)
+}
+# Remove illegal chromosome names
+if (! is.na(iparams$chrname.rm.pattern)) {
+	selectidx <- which(grepl(iparams$chrname.rm.pattern,names(chip.data$tags))==FALSE)
+	chip.data$tags <- chip.data$tags[selectidx]
+	chip.data$quality <- chip.data$quality[selectidx]
+}
+chip.data$num.tags <- sum(unlist(lapply(chip.data$tags,function(d) length(d))))
+
+# Read Control tagAlign/BAM files
+if (! is.na(iparams$control.file)) {
+	cat("Reading Control tagAlign/BAM file",iparams$control.file,"\n",file=stdout())
+	control.data <- read.align(ta.control.filename)
+	file.remove(ta.control.filename) # Delete temporary file    
+	if (length(control.data$tags)==0) {
+		stop('Error in control file format:', iparams$chip.file)
+	}    
+	cat("Control data read length",control.data$read.length,"\n",file=stdout())
+	# Remove illegal chromosome names
+	if (! is.na(iparams$chrname.rm.pattern)) {
+		selectidx <- which(grepl(iparams$chrname.rm.pattern,names(control.data$tags))==FALSE)
+		control.data$tags <- control.data$tags[selectidx]
+		control.data$quality <- control.data$quality[selectidx]
+	}
+	control.data$num.tags <- sum(unlist(lapply(control.data$tags,function(d) length(d))))
+}
+
+# Open multiple processes if required
+if (is.na(iparams$n.nodes)) {
+	cluster.nodes <- NULL
+} else {
+	library(snow)
+	cluster.nodes <- makeCluster(iparams$n.nodes,type="SOCK")
+}
+
+# #################################    
+# Calculate cross-correlation for various strand shifts
+# #################################    
+cat("Calculating peak characteristics\n",file=stdout())
+# crosscorr
+# $cross.correlation : Cross-correlation profile as an $x/$y data.frame
+# $peak : Position ($x) and height ($y) of automatically detected cross-correlation peak.
+# $whs: Optimized window half-size for binding detection (based on the width of the cross-correlation peak) 
+crosscorr <- get.binding.characteristics(chip.data,
+		srange=iparams$sep.range[c(1,3)],
+		bin=iparams$sep.range[2],
+		accept.all.tags=T,
+		cluster=cluster.nodes)
+if (!is.na(iparams$n.nodes)) {
+	stopCluster(cluster.nodes)
+}
+
+# Smooth the cross-correlation curve if required
+cc <- crosscorr$cross.correlation
+crosscorr$min.cc <- crosscorr$cross.correlation[ length(crosscorr$cross.correlation$y) , ] # minimum value and shift of cross-correlation
+cat("Minimum cross-correlation value", crosscorr$min.cc$y,"\n",file=stdout())
+cat("Minimum cross-correlation shift", crosscorr$min.cc$x,"\n",file=stdout())
+sbw <- 2*floor(ceiling(5/iparams$sep.range[2]) / 2) + 1 # smoothing bandwidth
+cc$y <- runmean(cc$y,sbw,alg="fast")
+
+# Compute cross-correlation peak
+bw <- ceiling(2/iparams$sep.range[2]) # crosscorr[i] is compared to crosscorr[i+/-bw] to find peaks
+peakidx <- (diff(cc$y,bw)>=0) # cc[i] > cc[i-bw]
+peakidx <- diff(peakidx,bw)
+peakidx <- which(peakidx==-1) + bw        
+
+# exclude peaks from the excluded region
+if ( is.nan(iparams$ex.range[2]) ) {
+	iparams$ex.range[2] <- chip.data$read.length+10
+}
+peakidx <- peakidx[(cc$x[peakidx] < iparams$ex.range[1]) | (cc$x[peakidx] > iparams$ex.range[2]) ]
+cc <- cc[peakidx,]
+
+# Find max peak position and other peaks within 0.9*max_peakvalue that are further away from maxpeakposition   
+maxpeakidx <- which.max(cc$y)
+maxpeakshift <- cc$x[maxpeakidx]
+maxpeakval <- cc$y[maxpeakidx]
+peakidx <-which((cc$y >= 0.9*maxpeakval) & (cc$x >= maxpeakshift)) 
+cc <- cc[peakidx,]
+
+# sort the peaks and get the top 3
+sortidx <- order(cc$y,decreasing=TRUE)
+sortidx <- sortidx[c(1:min(3,length(sortidx)))]
+cc.peak <- cc[sortidx,]
+
+# Override peak shift if user supplies peak shift
+if (! is.na(iparams$sep.peak)) {
+	cc.peak <- approx(crosscorr$cross.correlation$x,crosscorr$cross.correlation$y,iparams$sep.peak,rule=2)
+}
+cat("Top 3 cross-correlation values", paste(cc.peak$y,collapse=","),"\n",file=stdout())
+cat("Top 3 estimates for fragment length",paste(cc.peak$x,collapse=","),"\n",file=stdout())
+
+# Reset values in crosscorr
+crosscorr$peak$x <- cc.peak$x[1]
+crosscorr$peak$y <- cc.peak$y[1]
+
+# Compute window half size
+whs.thresh <- crosscorr$min.cc$y + (crosscorr$peak$y - crosscorr$min.cc$y)/3
+crosscorr$whs <- max(crosscorr$cross.correlation$x[crosscorr$cross.correlation$y >= whs.thresh])
+cat("Window half size",crosscorr$whs,"\n",file=stdout())
+
+# Compute phantom peak coefficient
+ph.peakidx <- which( ( crosscorr$cross.correlation$x >= ( chip.data$read.length - round(2*iparams$sep.range[2]) ) ) & 
+                     ( crosscorr$cross.correlation$x <= ( chip.data$read.length + round(1.5*iparams$sep.range[2]) ) ) )
+ph.peakidx <- ph.peakidx[ which.max(crosscorr$cross.correlation$y[ph.peakidx]) ]
+crosscorr$phantom.cc <- crosscorr$cross.correlation[ph.peakidx,]
+cat("Phantom peak location",crosscorr$phantom.cc$x,"\n",file=stdout())
+cat("Phantom peak Correlation",crosscorr$phantom.cc$y,"\n",file=stdout())
+crosscorr$phantom.coeff <- crosscorr$peak$y / crosscorr$phantom.cc$y
+crosscorr$phantom.coeff <- crosscorr$peak$y / crosscorr$min.cc$y
+cat("Normalized Strand cross-correlation coefficient (NSC)",crosscorr$phantom.coeff,"\n",file=stdout())
+crosscorr$rel.phantom.coeff <- (crosscorr$peak$y - crosscorr$min.cc$y) / (crosscorr$phantom.cc$y - crosscorr$min.cc$y)
+cat("Relative Strand cross-correlation Coefficient (RSC)",crosscorr$rel.phantom.coeff,"\n",file=stdout())
+crosscorr$phantom.quality.tag <- NA
+if ( (crosscorr$rel.phantom.coeff >= 0) & (crosscorr$rel.phantom.coeff < 0.25) ) {
+	crosscorr$phantom.quality.tag <- -2
+} else if ( (crosscorr$rel.phantom.coeff >= 0.25) & (crosscorr$rel.phantom.coeff < 0.5) ) {
+	crosscorr$phantom.quality.tag <- -1
+} else if ( (crosscorr$rel.phantom.coeff >= 0.5) & (crosscorr$rel.phantom.coeff < 1) ) {
+	crosscorr$phantom.quality.tag <- 0
+} else if ( (crosscorr$rel.phantom.coeff >= 1) & (crosscorr$rel.phantom.coeff < 1.5) ) {
+	crosscorr$phantom.quality.tag <- 1
+} else if ( (crosscorr$rel.phantom.coeff >= 1.5) ) {
+	crosscorr$phantom.quality.tag <- 2
+}
+cat("Phantom Peak Quality Tag",crosscorr$phantom.quality.tag,"\n",file=stdout())
+
+# Output result to result file if required
+#Filename\tnumReads\tPeak_shift\tPeak_Correlation\tRead_length\tPhantomPeak_Correlation\tMin_Correlation_Shift\tMin_Correlation\tNormalized_CrossCorrelation_Coefficient\tRelative_CrossCorrelation_Coefficient\tQualityTag)
+if (! is.na(iparams$output.result.file)) {
+	cat(get.file.parts(iparams$chip.file)$fullname,
+			chip.data$num.tags,
+			paste(cc.peak$x,collapse=","),
+			paste(cc.peak$y,collapse=","),
+			crosscorr$phantom.cc$x,
+			crosscorr$phantom.cc$y,
+			crosscorr$min.cc$x,
+			crosscorr$min.cc$y,
+			crosscorr$phantom.coeff,
+			crosscorr$rel.phantom.coeff,
+			crosscorr$phantom.quality.tag,
+			sep="\t",
+			file=iparams$output.result.file,
+			append=TRUE)
+	cat("\n",
+			file=iparams$output.result.file,
+			append=TRUE)    
+}
+
+# Save figure if required
+if (! is.na(iparams$output.plot.file)) {
+	pdf(file=iparams$output.plot.file,width=5,height=5)
+	par(mar = c(4,3.5,2,0.5), mgp = c(1.5,0.5,0), cex = 0.8);
+	plot(crosscorr$cross.correlation,
+			type='l',
+			xlab=sprintf("strand-shift (%s)",paste(cc.peak$x,collapse=",")),
+			ylab="cross-correlation")
+	abline(v=cc.peak$x,lty=2,col=2)
+	abline(v=crosscorr$phantom.cc$x,lty=2,col=4)
+	title(main=get.file.parts(iparams$chip.file)$fullname,
+	      sub=sprintf("NSC=%g,RSC=%g,Qtag=%d",crosscorr$phantom.coeff,crosscorr$rel.phantom.coeff,crosscorr$phantom.quality.tag))
+	dev.off();    
+}
+
+# Save RData file if required
+if (! is.na(iparams$output.rdata.file)) {
+	save(iparams,
+			crosscorr,
+			cc.peak,
+			file=iparams$output.rdata.file);    
+}
+
+# #################################    
+# Call peaks
+# #################################
+
+if ( !is.na(iparams$output.npeak.file) || !is.na(iparams$output.rpeak.file) ) {
+	
+	# Remove local tag anomalies
+	cat('Removing read stacks\n',file=stdout())
+	chip.data <- remove.local.tag.anomalies(chip.data$tags)
+	control.data <- remove.local.tag.anomalies(control.data$tags)
+	
+	# Open multiple processes if required
+	if (is.na(iparams$n.nodes)) {
+		cluster.nodes <- NULL
+	} else {
+		cluster.nodes <- makeCluster(iparams$n.nodes,type="SOCK")
+	}
+	
+	# Find peaks
+	cat('Finding peaks\n',file=stdout())
+	if (!is.na(iparams$npeak)) {
+		iparams$fdr <- 0.99
+	}
+	narrow.peaks <- find.binding.positions(signal.data=chip.data,control.data=control.data,fdr=iparams$fdr,method=spp:::tag.lwcc,whs=crosscorr$whs,cluster=cluster.nodes)
+	if (!is.na(iparams$n.nodes)) {
+		stopCluster(cluster.nodes)
+	}
+	cat(paste("Detected",sum(unlist(lapply(narrow.peaks$npl,function(d) length(d$x)))),"peaks"),"\n",file=stdout())
+	
+	# Write to narrowPeak file
+	if (!is.na(iparams$output.npeak.file)) {
+		write.narrowpeak.binding(narrow.peaks,iparams$output.npeak.file,margin=round(crosscorr$whs/2),npeaks=iparams$npeak)
+		system(paste('gzip -f ',iparams$output.npeak.file))
+	}
+	
+	# Compute and write regionPeak file
+	if (!is.na(iparams$output.rpeak.file)) {
+		region.peaks <- add.broad.peak.regions(chip.data,control.data,narrow.peaks,window.size=max(50,round(crosscorr$whs/4)),z.thr=9)
+		write.narrowpeak.binding(region.peaks,iparams$output.rpeak.file,margin=round(crosscorr$whs/2),npeaks=iparams$npeak)
+		system(paste('gzip -f ',iparams$output.rpeak.file))
+	}
+	
+	# Save Rdata file    
+	if (! is.na(iparams$output.rdata.file)) {
+		save(iparams,
+				crosscorr,
+				cc.peak,
+				narrow.peaks,
+				region.peaks,
+				file=iparams$output.rdata.file);    
+	}
+	
+}
+
+


### PR DESCRIPTION
Hello again! I originally made a pull request called **Use Bioconda ChromHMM distribution** but I made some additional changes that might be useful and so I am wrapping everything up in a new pull request here.

I will try and summarize the changes I have made below. I realized after making commits that it would have made more sense to refer to "local paths" as absolute paths. The take away is that I was trying to refer to paths that where specific to one machine.

## Add chromHMM.yaml

Here I basically just copied the format of other `yaml` files for conda tools and replaced `chromhmm` as the dependency so it could be used in the snakemake rule files.

## Use conda ChromHMM in ` Rules/ChromHMM.smk `

It seems that once installed with conda ChromHMM can be called as `ChromHMM.sh`. I first tested this in just a personal conda environment on Ubuntu so I am not sure how this may differ on other operating systems. 

First, I followed the format lased in other rules and added 
```
conda:
    '../Envs/chromHMM.yaml'
```
to any rule that called ChromHMM.

Next in the shell commands, I replaced `java -mx10000M -jar /home/ckern/ChromHMM/ChromHMM.jar` where ever it occurred with `ChromHMM.sh`.

### Testing ChromHMM changes

I do not have data to fully test the pipeline with these changes but I did create a small proof of concept snakefile which is below and was named `snake-test`.

```
rule all:
    input: "results.txt"

rule test_chip:
    output:
        "results.txt"
    conda:
        "Envs/chromHMM.yaml"
    shell:'''
    ChromHMM.sh Version> {output}
    '''
```
I created a clean conda environment with the command `conda create -y --name clean -c conda-forge -c bioconda snakemake-minimal` and then executed this tiny snakefile with the command `snakemake -s snake-test -j 1 --use-conda`. This was just to test that the `chromHMM.yaml` environment file could be used successfully and that ChromHMM could be called in this way. 

The snakefile ran successfully and produced `results.txt` with the following content.
```
This is Version 1.14 of ChromHMM (c) Copyright 2008-2012 Massachusetts Institute of Technology
```
which is what I was expecting.

Based on this I believe ChromHMM calls should execute normally. However, I have not tested on Windows or Mac OS or in a full scale run.

## Remove absolute paths in `Rules/DeployTrackHub.smk`

Looks like some absolute filepaths have made it this file. There were a couple instances of `/home/ckern/bin/bedClip` being used instead of just `bedClip`. The conda environment used by these rules already specifies `ucsc-bedclip` as dependency so just with that change those rules should be good to go.

Similarly, in some rules `bedToBigBed` was being called with `/home/ckern/bin/bedToBigBed`. It is available through conda so I added it as a dependency to the `bdg2bw.yaml` environment file along with `conda: '../Env/bdg2bw.yaml'` to the effected rules.

##  Use bedtools.yaml environment file in a couple rules

There were a couple rules that seemed to call bedtools but did not specify a conda environment so I just added `conda: ./Env/bedtools.yaml` to these.

## Add note about call to `run_spp.R`

This looked like another possible absolute path issue. The rule run_spp executes `Rscript /home/ckern/phantompeakqualtools/run_spp.R`. I am not sure if this rule is actually run in the pipeline but if it is it would likely fail. I also did not see `run_spp.R` in the `scripts` folder so I was mostly wondering if this should be marked as depreciated.  

## Small change for clarity to the README

I noticed that in the `run.sh` script the ----cluster-config` argument has an absolute path specified so I just added a note that this would have to be changed to run on "your" machine.

That is all, thanks and have a good one!





 